### PR TITLE
Clarify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Repository for testing different versions of ergocub using gazebo.
 ## Requirements:
 
 - [`gazebo`](http://gazebosim.org/)
-- [`robotology-superbuild`](https://github.com/robotology/robotology-superbuild)
+- [`gazebo-yarp-plugins`](https://github.com/robotology/gazebo-yarp-plugins)
+- [`icub-models`](https://github.com/robotology/icub-models)
+
+A convenient way to install the required software and their dependencies is to use the [`robotology-superbuild`](https://github.com/robotology/robotology-superbuild).
 
 ## Installation:
 


### PR DESCRIPTION
From what I see from the files in the repo, only `gazebo-yarp-plugins`  and `icub-models` are required, and could also be installed on their own or via conda packages. So I modified the README to clarify that, making it clear in any case the robotology-superbuild is probably the suggeted way to install them. 