### PR TITLE
Modify stickbot urdf 

### DIFF
--- a/models/stickBot/model.urdf
+++ b/models/stickBot/model.urdf
@@ -831,7 +831,7 @@
     <parent link="neck_3"/>
     <child link="camera_tilt"/>
     <axis xyz="0. 0. 1."/>
-    <origin xyz="0.05305 0.0 0.08205" rpy="-1.5707926535897934 9.265358979305728e-05 -3.141592653589793"/>
+    <origin xyz="0.05305 0.0 0.08205" rpy="1.5708 3.1415 0.0"/>
   </joint>
   <joint name="lidar_joint" type="revolute">
     <dynamics damping="0.06" friction="0.0"/>
@@ -847,7 +847,7 @@
     <parent link="root_link"/>
     <child link="r_hip_1"/>
     <axis xyz=" 0. -1.  0."/>
-    <origin xyz="0.0216 -0.040549999999999996 -0.021599999999999994" rpy="0.0 0.0 0.0"/>
+    <origin xyz="0.0216 -0.040549999999999996 0.0" rpy="0.0 0.0 0.0"/>
   </joint>
   <joint name="r_hip_roll" type="revolute">
     <dynamics damping="0.06" friction="0.0"/>
@@ -916,7 +916,7 @@
     <parent link="root_link"/>
     <child link="l_hip_1"/>
     <axis xyz=" 0. -1.  0."/>
-    <origin xyz="0.0216 0.04045000000000001 -0.021599999999999994" rpy="0.0 0.0 0.0"/>
+    <origin xyz="0.0216 0.04045000000000001 0.0" rpy="0.0 0.0 0.0"/>
   </joint>
   <joint name="l_hip_roll" type="revolute">
     <dynamics damping="0.06" friction="0.0"/>


### PR DESCRIPTION
This PR addresses #15   and changes the links masses as per https://github.com/robotology/icub-models/issues/94, now the robot weight is equal to 

```
idyntree-model-info -m model.urdf --total-mass
[WARNING] SensorElement :: setAttributes : iDynTree does not support sensor of type depth
[WARNING] SensorElement :: setAttributes : iDynTree does not support sensor of type camera
The total mass of model is 52.0102 Kg.
```

Note that there was the need of recomputing the inertias since the mass changed, I used directly the script inside ergocub gazebo simulator to perform the computation for the changes. 
:warning: the mass of the robot is not exactly equal to the one of icub3 but there are new links (such as the lidar) that increase the mass of the robot. 

Since I was already there I have: 
- Substitute  Nan  with zeros for the `base_link_fixed_joint`; #8 
- Substitute the continuous joint  with a revolute one for the `r_wrist_yaw` and add the limits; #13 
- Removed the masses for the fictitious links `l_sole`, `r_sole`, `imu_frame`, and `base_link` as it is in iCub3 

C.C. @AlexAntn @GrmanRodriguez @Nicogene  @lrapetti @DanielePucci 