### PR TITLE
Permit to use stickBot model with default compilation options of gazebo-yarp-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo contains a `gazebo` model, starting from iCub3, and some scripts that 
 - [`urdfpy`](https://github.com/mmatl/urdfpy)
 - [`dataclasses`](https://pypi.org/project/dataclasses/)
 
-:warning: **Since `stickBot` has been now ported to the new nws/nwc architecture, it requires that the CMake flag `GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS` has to be set to `ON`**
+:warning: **If you are using the robotology-distro < 2022.02 the stickBot model requires that gazebo-yarp-plugins is compiled with CMake flag `GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS`  has to be set to `ON`. This constraint is not present when using distro >= 2022.02.**
 
 ## Installation:
 

--- a/conf_stickBot/gazebo_icub_head_without_eyes_V2_7/gazebo_icub_head_without_eyes_V2_7.ini
+++ b/conf_stickBot/gazebo_icub_head_without_eyes_V2_7/gazebo_icub_head_without_eyes_V2_7.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName head_device
+disableImplicitNetworkWrapper
 
 #[WRAPPER]
 # name of the wrapper device to be instatiated by the factory

--- a/conf_stickBot/gazebo_icub_laser/gazebo_icub_laser.ini
+++ b/conf_stickBot/gazebo_icub_laser/gazebo_icub_laser.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName las360
+disableImplicitNetworkWrapper
 robotName ${gazeboYarpPluginsRobotName}
 period 10
 

--- a/conf_stickBot/gazebo_icub_left_arm_no_hand_for_no_hand_model/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
+++ b/conf_stickBot/gazebo_icub_left_arm_no_hand_for_no_hand_model/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName left_arm_no_hand_mc
+disableImplicitNetworkWrapper
 
 #[WRAPPER]
 # name of the wrapper device to be instatiated by the factory

--- a/conf_stickBot/gazebo_icub_left_leg/gazebo_icub_left_leg.ini
+++ b/conf_stickBot/gazebo_icub_left_leg/gazebo_icub_left_leg.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName left_leg_device
+disableImplicitNetworkWrapper
 
 #[WRAPPER]
 # name of the wrapper device to be instatiated by the factory

--- a/conf_stickBot/gazebo_icub_rgbd_camera_eyes/gazebo_icub_rgbd_camera_eyes.ini
+++ b/conf_stickBot/gazebo_icub_rgbd_camera_eyes/gazebo_icub_rgbd_camera_eyes.ini
@@ -1,5 +1,6 @@
 [include "../gazebo_icub_robotname.ini"]
 yarpDeviceName headDepthCamera
+disableImplicitNetworkWrapper
 
 [CAMERA_PARAM]
 focalLengthX 570.3422241210938

--- a/conf_stickBot/gazebo_icub_right_arm_no_hand_for_no_hand_model/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
+++ b/conf_stickBot/gazebo_icub_right_arm_no_hand_for_no_hand_model/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName right_arm_no_hand_mc
+disableImplicitNetworkWrapper
 #[WRAPPER]
 # name of the wrapper device to be instatiated by the factory
 #device controlboardwrapper2

--- a/conf_stickBot/gazebo_icub_right_leg/gazebo_icub_right_leg.ini
+++ b/conf_stickBot/gazebo_icub_right_leg/gazebo_icub_right_leg.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName right_leg_device
+disableImplicitNetworkWrapper
 
 #[WRAPPER]
 # name of the wrapper device to be instatiated by the factory

--- a/conf_stickBot/gazebo_icub_torso/gazebo_icub_torso.ini
+++ b/conf_stickBot/gazebo_icub_torso/gazebo_icub_torso.ini
@@ -1,6 +1,7 @@
 [include "../gazebo_icub_robotname.ini"]
 
 yarpDeviceName torso_device
+disableImplicitNetworkWrapper
 
 #[WRAPPER]
 # name of the wrapper device to be instatiated by the factory

--- a/models/stickBot/model.urdf
+++ b/models/stickBot/model.urdf
@@ -1301,7 +1301,7 @@
       </force_torque>
       <pose>-0.004350133156978329 3.632573233880443e-07 -0.05430003872406172 3.141592646862139 -3.104683320142575e-08 -1.5707962571980942</pose>
       <plugin name="left_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-        <yarpConfigurationString>(yarpDeviceName left_upper_arm_strain)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName left_upper_arm_strain) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1323,7 +1323,7 @@
       </force_torque>
       <pose>-0.006849946385389875 2.1904996055921444e-07 -0.05429998157789099 3.141592644717707 4.094299285979593e-08 1.5707964185756365</pose>
       <plugin name="right_arm_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-        <yarpConfigurationString>(yarpDeviceName right_upper_arm_strain)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName right_upper_arm_strain) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1345,7 +1345,7 @@
       </force_torque>
       <pose>0.0 0.0 0.022299999999999986 0.0 -0.0 -2.094395210586932</pose>
       <plugin name="left_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-        <yarpConfigurationString>(yarpDeviceName left_lower_leg_front_strain)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName left_lower_leg_front_strain) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1367,7 +1367,7 @@
       </force_torque>
       <pose>0.0 0.0 0.022299999999999986 0.0 -0.0 -2.094395210586932</pose>
       <plugin name="left_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-        <yarpConfigurationString>(yarpDeviceName left_lower_leg_rear_strain)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName left_lower_leg_rear_strain) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1389,7 +1389,7 @@
       </force_torque>
       <pose>0.0 0.0 0.022299999999999986 0.0 -0.0 -2.094395210586932</pose>
       <plugin name="right_foot_front_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-        <yarpConfigurationString>(yarpDeviceName right_lower_leg_front_strain)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName right_lower_leg_front_strain) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1411,7 +1411,7 @@
       </force_torque>
       <pose>0.0 0.0 0.022299999999999986 0.0 -0.0 -2.094395210586932</pose>
       <plugin name="right_foot_rear_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-        <yarpConfigurationString>(yarpDeviceName right_lower_leg_rear_strain)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName right_lower_leg_rear_strain) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1429,7 +1429,7 @@
       <update_rate>100</update_rate>
       <pose>0.0034999999997785457 0.0054999999863750895 0.1013340000004441 -3.141592653589793 -4.20000162559822e-15 -1.570796326794897</pose>
       <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationString>(yarpDeviceName head-inertial)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName head-inertial) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>
@@ -1517,7 +1517,7 @@
       <update_rate>100</update_rate>
       <pose>0.0894115 0.0175 0.09929950000000001 -1.5707963267948968 -0.0 -1.5707963267948968</pose>
       <plugin name="iCub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationString>(yarpDeviceName chest-inertial)</yarpConfigurationString>
+        <yarpConfigurationString>(yarpDeviceName chest-inertial) (disableImplicitNetworkWrapper)</yarpConfigurationString>
       </plugin>
     </sensor>
   </gazebo>


### PR DESCRIPTION
Together with https://github.com/robotology/gazebo-yarp-plugins/pull/586, this PR permit to run the stickBot simulation model with the default compilation options of `gazebo-yarp-plugins` . When using earlier version of `gazebo-yarp-plugins` the added parameter are harmless. With an additional modification (coming in https://github.com/icub-tech-iit/ergocub-gazebo-simulations/pull/26) this would permit to use this models with conda binaries of `gazebo-yarp-plugins`. fyi @lrapetti 