### PR TITLE
Explicitly pass LANGUAGES NONE to CMake's project invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,5 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/models/ DESTINATION share/iCub/robots)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/conf_stickBot DESTINATION share/iCub)
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/scripts/modify_robot.py ${CMAKE_CURRENT_SOURCE_DIR}/scripts/fix_inertias.py DESTINATION bin )
-E
 # TODO: what do we do about the conf.ini? it should not be installed with the binaries, but we don't really have a context to put it on either...
 


### PR DESCRIPTION
To test https://github.com/icub-tech-iit/ergocub-gazebo-simulations/issues/29 I was installing the project in a context without any C++ compiler installed (as it commonly happens to a system used by a mechanical engineer or electronic engineer) and the `cmake .`  failed with error:
~~~
(ergocubgazebosim) C:\src\ergocub-gazebo-simulations\build>cmake -GNinja -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library .
.
-- The C compiler identification is unknown
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:8 (project):
  No CMAKE_C_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
  the compiler, or to the compiler name if it is in the PATH.


CMake Error at CMakeLists.txt:8 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
~~~

However, no C++ compiler is actually necessary in this project, so we can simply tell CMake that no languages are used in the project (as opposed to the default C and C++) so it can be used also in a system with no C++ compilers.