### PR TITLE
Add whole-body-estimators to conda packages to install if one wants to run simulations from binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mamba create -n ergocubsim
 Then, you can activate the environment and install the dependencies:
 ~~~
 mamba activate ergocubsim
-mamba install -c conda-forge -c robotology robotology-distro yarp icub-models gazebo-yarp-plugins gazebo whole-body-controllers walking-controllers cmake ninja
+mamba install -c conda-forge -c robotology robotology-distro yarp icub-models gazebo-yarp-plugins gazebo whole-body-controllers walking-controllers cmake ninja whole-body-estimators
 ~~~
 
 Clone this repo and create a `build` directory on it:


### PR DESCRIPTION
The `wholebodydynamics` YARP device is used inside the Gazebo simulations, so we need to also install the `whole-body-estimators` conda package.