### PR TITLE
Adapt hold_box.sh script to run on Windows

### DIFF
--- a/experiments/hold_box/cleanup.sh
+++ b/experiments/hold_box/cleanup.sh
@@ -2,8 +2,20 @@
 
 echo "Cleaning up"
 sleep 1
-killall -9 yarpserver
-killall -9 ctpService
-killall -9 gazebo
-killall -9 gzserver
-killall -9 gzclient
+
+if [[ -z $COMSPEC ]];
+then
+    # Not Windows
+    killall -9 yarpserver
+    killall -9 ctpService
+    killall -9 gazebo
+    killall -9 gzserver
+    killall -9 gzclient
+else
+    # Windows
+    taskkill //F //IM yarpserver.exe
+    taskkill //F //IM ctpService.exe
+    taskkill //F //IM gazebo.exe
+    taskkill //F //IM gzserver.exe
+    taskkill //F //IM gzclient.exe
+fi;

--- a/experiments/hold_box/hold_box.sh
+++ b/experiments/hold_box/hold_box.sh
@@ -9,7 +9,14 @@ yarpserver --write --silent &
 
 sleep 1
 
-export YARP_CLOCK=/clock
+if [[ -z $COMSPEC ]];
+then
+    # Not Windows
+    export YARP_CLOCK=/clock
+else
+    # Windows
+    export YARP_CLOCK=//clock
+fi;
 
 # Run gazebo world
 gzserver -slibgazebo_yarp_clock.so  hold_box.world &
@@ -21,11 +28,11 @@ ctpService --robot icubSim --part left_arm &
 ctpService --robot icubSim --part right_arm &
 sleep 5
 
-echo "ctpq time 1.0 off 0 pos (-44.4 12.0 0 45 -88 3.8 0.02)" | yarp rpc /ctpservice/left_arm/rpc
-echo "ctpq time 1.0 off 0 pos (-44.4 12.0 0 45 -88 3.8 0.02)" | yarp rpc /ctpservice/right_arm/rpc
+echo "ctpq time 1.0 off 0 pos (-44.4 12.0 0 45 -88 3.8 0.02)" | yarp rpc " /ctpservice/left_arm/rpc"
+echo "ctpq time 1.0 off 0 pos (-44.4 12.0 0 45 -88 3.8 0.02)" | yarp rpc " /ctpservice/right_arm/rpc"
 sleep 5
 
 # Import the box
-echo "loadModelFromFile \"../../build/hold_box/sdf_files\"" | yarp rpc /world_input_port
+echo "loadModelFromFile \"../../build/hold_box/sdf_files\"" | yarp rpc " /world_input_port"
 
 unset YARP_ROBOT_NAME


### PR DESCRIPTION
This permit to run the `hold_box.script.sh` experiment on Windows, as discussed in https://github.com/icub-tech-iit/ergocub-gazebo-simulations/issues/29#issuecomment-1067084821 . 

The changes are the following:
* On Windows, neither Git Bash nor the system provide `killall`, so `taskill` is used instead.
* On Git Bash on Windows, string that start with `/` are implicitly interpreted as path and convert to a path, see https://github.com/bmatzelle/gow/issues/196 . To avoid problem related to this, we:
  * Set `YARP_CLOCK` to `//clock` on Windows
  * For `yarp rpc` calls, we specify the argument prefixed with a space, to avoid any problem (this strategy does not work when defining the `YARP_CLOCK`

The changes are unfortunatly far from being intuitive/mantainable, and this is the reason why for multiplatform multiprogram logic we use either yarpmanager of Python scripts that use the `subprocess` library ( https://docs.python.org/3/library/subprocess.html ).