### PR TITLE
tuned stickBot position-control for walking

### DIFF
--- a/conf_stickBot/gazebo_icub_left_leg/gazebo_icub_left_leg.ini
+++ b/conf_stickBot/gazebo_icub_left_leg/gazebo_icub_left_leg.ini
@@ -43,15 +43,15 @@ max_damping   100.0  100.0  100.0  100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0   40.0   40.0   40.0   40.0   40.0
-kd            0.35   0.35   0.35   0.35   0.35   0.35
-ki            0.35   0.35   0.35   0.35   0.35   0.35
-maxInt        9999   9999   9999   9999   9999   9999
-maxOutput     9999   9999   9999   9999   9999   9999
-shift         0.0    0.0    0.0    0.0    0.0    0.0
-ko            0.0    0.0    0.0    0.0    0.0    0.0
-stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
-stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
+kp            70.0   70.0   40.0   100.0   100.0   100.0
+kd            0.15   0.15   0.35   0.15    0.15     0.15
+ki            0.17   0.17   0.35   0.35    0.35     0.35
+maxInt        9999   9999   9999   9999    9999     9999
+maxOutput     9999   9999   9999   9999    9999     9999
+shift         0.0    0.0    0.0    0.0     0.0      0.0
+ko            0.0    0.0    0.0    0.0     0.0      0.0
+stictionUp    0.0    0.0    0.0    0.0     0.0      0.0
+stictionDwn   0.0    0.0    0.0    0.0     0.0      0.0
 
 [VELOCITY_CONTROL]
 controlUnits  metric_units

--- a/conf_stickBot/gazebo_icub_right_leg/gazebo_icub_right_leg.ini
+++ b/conf_stickBot/gazebo_icub_right_leg/gazebo_icub_right_leg.ini
@@ -43,15 +43,15 @@ max_damping   100.0  100.0  100.0  100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0   40.0   40.0   40.0   40.0   40.0
-kd            0.35   0.35   0.35   0.35   0.35   0.35
-ki            0.35   0.35   0.35   0.35   0.35   0.35
-maxInt        9999   9999   9999   9999   9999   9999
-maxOutput     9999   9999   9999   9999   9999   9999
-shift         0.0    0.0    0.0    0.0    0.0    0.0
-ko            0.0    0.0    0.0    0.0    0.0    0.0
-stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
-stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
+kp            70.0   70.0   40.0   100.0   100.0   100.0
+kd            0.15   0.15   0.35   0.15    0.15     0.15
+ki            0.17   0.17   0.35   0.35    0.35     0.35
+maxInt        9999   9999   9999   9999    9999     9999
+maxOutput     9999   9999   9999   9999    9999     9999
+shift         0.0    0.0    0.0    0.0     0.0      0.0
+ko            0.0    0.0    0.0    0.0     0.0      0.0
+stictionUp    0.0    0.0    0.0    0.0     0.0      0.0
+stictionDwn   0.0    0.0    0.0    0.0     0.0      0.0
 
 [VELOCITY_CONTROL]
 controlUnits  metric_units

--- a/conf_stickBot/gazebo_icub_torso/gazebo_icub_torso.ini
+++ b/conf_stickBot/gazebo_icub_torso/gazebo_icub_torso.ini
@@ -43,9 +43,9 @@ max_damping   100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0  40.0  40.0
-kd            0.35  0.35  0.35
-ki            0.35  0.35  0.35
+kp            70.0  70.0  70.0
+kd            0.15 0.15 0.15
+ki            0.17 0.17 0.17
 maxInt        9999  9999  9999
 maxOutput     9999  9999  9999
 shift         0.0   0.0   0.0


### PR DESCRIPTION
With reference to [this pull request](https://github.com/robotology/icub-models-generator/pull/219) and after some tests on my machine as well as @SimoneMic from HSP team, I am updating the values of the low-level position-control pid gains for the `walking-controllers` simulation with the `stickBot`. These values seems to give "better/ok" results on both our machines.

P.S.
I opened the PR directly on master since the PR should not, in theory, break any other simulation related activity or experiments. Feel free to suggest a different approach to this, if you deem it necessary. 