### PR TITLE
Update Lidar and camera joints frame origins according to latest head

### DIFF
--- a/models/stickBot/model.urdf
+++ b/models/stickBot/model.urdf
@@ -854,18 +854,18 @@
   <joint name="camera_tilt_joint" type="revolute">
     <dynamics damping="0.06" friction="0.0"/>
     <limit effort="50000.0" velocity="120.0" lower="-0.7853981633974483" upper="0.7853981633974483"/>
-    <parent link="neck_3"/>
+    <parent link="head"/>
     <child link="camera_tilt"/>
     <axis xyz="0. 0. 1."/>
-    <origin xyz="0.05305 0.0 0.08205" rpy="1.5708 3.1415 0.0"/>
+    <origin xyz="0.055513 0.00017 0.076925" rpy="1.5708 3.1415 0.0"/>
   </joint>
   <joint name="lidar_joint" type="revolute">
     <dynamics damping="0.06" friction="0.0"/>
     <limit effort="50000.0" velocity="120.0" lower="-0.7853981633974483" upper="0.7853981633974483"/>
-    <parent link="neck_3"/>
+    <parent link="head"/>
     <child link="lidar"/>
     <axis xyz="0. 0. 1."/>
-    <origin xyz="0.0 0.0 0.17" rpy="0.0 0.0 0.0"/>
+    <origin xyz="0.00117 0.00115 0.1268" rpy="0.0 0.0 0.0"/>
   </joint>
   <joint name="r_hip_pitch" type="revolute">
     <dynamics damping="2.0" friction="0.0"/>
@@ -1466,7 +1466,7 @@
     <sensor name="realsense_head_rgbd" type="depth">
       <always_on>1</always_on>
       <update_rate>30</update_rate>
-      <pose>0.0 0.0 0.0 0.0 -1.57079 0.0</pose>
+      <pose>-0.0113 0.0 0.0 0.0 -1.57079 0.0</pose>
       <camera name="intel_realsense_rgbd_camera">
         <pose>0 0 0 -1.57079 -1.57079 3.14159</pose>
         <horizontal_fov>2.1</horizontal_fov>
@@ -1496,14 +1496,14 @@
   </gazebo>
   <sensor name="realsense_head_rgbd" type="camera">
     <parent link="camera_tilt"/>
-    <origin rpy="0.0 -1.57079 0.0" xyz="0.0 0.0 0.0"/>
+    <origin rpy="0.0 -1.57079 0.0" xyz="-0.0113 0.0 0.0"/>
   </sensor>
 
   <gazebo reference="lidar">
     <sensor name="lasersensor_head" type="ray">
         <always_on>1</always_on>
         <update_rate>40</update_rate>
-        <pose frame=''>0.0 0.0 0.02 0.0 0.0 0.0</pose>
+        <pose frame=''>0.0 0.0 0.0105 0.0 0.0 0.0</pose>
         <visualize>true</visualize>
         <ray>
           <scan>
@@ -1532,7 +1532,7 @@
   </gazebo>
   <sensor name="lasersensor_head" type="ray">
     <parent link="lidar"/>
-    <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.025"/>
+    <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0105"/>
   </sensor>
 
   <gazebo reference="chest">


### PR DESCRIPTION
This PR aims to update the frame origin positions of the Realsense Camera and Lidar on the ergoCub head, according to the latest mechanical design. Additionally, it replaces their parents link to `head` from `neck_3`, since the sensors should move if the head rotates along yaw. 

See below for the reference frames used to find the new values:

## Lidar

**Head to CoM**
![6b685b155ff34274b8b203c8dbb2ed6e](https://user-images.githubusercontent.com/38140169/160131254-4d60b282-61eb-483a-b0c9-b0f65c77b982.png)

**Head to sensor**
![e180fc276e384e258db785e07b31bdef](https://user-images.githubusercontent.com/38140169/160131207-dae33685-d262-4fbc-83a2-aead99fea7da.png)

## Camera

**Head to tilting frame**
![ed7517b216d948ff9008c4bd477c87db](https://user-images.githubusercontent.com/38140169/160132099-b05a5b01-24c2-4f1c-ad38-edf406ba50d2.png)

**Head to RGB frame** 
![7e9fc705fe2f4ca3b3b3400bd2fdaa16](https://user-images.githubusercontent.com/38140169/160132068-0262b314-2d06-40f6-beaf-1d9077f70b92.png)

